### PR TITLE
Fix a key error when project id is missing

### DIFF
--- a/pytodoist/todoist.py
+++ b/pytodoist/todoist.py
@@ -384,8 +384,11 @@ class User(TodoistObject):
         for task_json in tasks_json:
             task_id = task_json['id']
             project_id = task_json['project_id']
-            project = self.projects[project_id]
-            self.tasks[task_id] = Task(task_json, project)
+            try:
+                project = self.projects[project_id]
+                self.tasks[task_id] = Task(task_json, project)
+            except KeyError:
+                continue
 
     def _sync_notes(self, notes_json):
         """"Populate the user's notes from a JSON encoded list."""


### PR DESCRIPTION
Some context: I found this bug after picking up a project from a while back. This had originally worked fine, until recently. The `KeyError` happens immediately, during the `sync_tasks` call when logging in, so it was a bit of a blocker. I don't know how the state of the projects got out of sync in order to cause this, but I figured this might be worthwhile to check.
