### PR TITLE
Fix deleting labels

### DIFF
--- a/pytodoist/todoist.py
+++ b/pytodoist/todoist.py
@@ -1568,7 +1568,7 @@ class Label(TodoistObject):
         >>> label.delete()
         """
         args = {'id': self.id}
-        _perform_command(self.owner, 'label_update', args)
+        _perform_command(self.owner, 'label_delete', args)
 
 
 class Filter(TodoistObject):


### PR DESCRIPTION
A spelling mistake in Label.delete() was preventing the deletion of labels.