### PR TITLE
Close #34

### DIFF
--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -11,3 +11,4 @@ Contributors
 
 * Elias Kuthe <elias.kuthe@web.de>
 * Ernie Hershey <github@ernie.org>
+* Ethan Swan <ethanpswan@gmail.com>

--- a/pytodoist/todoist.py
+++ b/pytodoist/todoist.py
@@ -219,6 +219,20 @@ class TodoistObject(object):
             self.to_update.add(key)  # Don't update on __init__.
         super(TodoistObject, self).__setattr__(key, value)
 
+    def __getattribute__(self, name):
+        '''
+        Return immutable versions of mutable attributes.
+
+        We can't detect changes to mutable attributes (calling .append() on
+        lists), so when an attribute is a list, we return it to the user as a
+        tuple instead, forcing them to overwrite it if they wish to modify it.
+        '''
+        attribute = object.__getattribute__(self, name)
+        if isinstance(attribute, (list)):
+            return tuple(attribute)
+        else:
+            return attribute
+
 
 class User(TodoistObject):
     """A Todoist User that has the following attributes:


### PR DESCRIPTION
This PR uses `__getattribute__` to intercept user attempts to access attributes that are stored as lists, forcing them to overwrite the attribute rather than update it in place. In-place updates aren't caught by `__setattr__`, and thus changes made in-place weren't being synced back to Todoist on `.update()`.

I also added myself as a contributor in `credits.rst`, because I saw the contributing guide suggested that.

As for quality checks, the test suite still passes and didn't require any changes. I also tested this change interactively.